### PR TITLE
修复木板右键箱子掉落物品

### DIFF
--- a/kubejs/client_scripts/tooltip.js
+++ b/kubejs/client_scripts/tooltip.js
@@ -8,7 +8,7 @@ tooltip.add("minecraft:deepslate_redstone_ore", [`§6原版红石矿石已被朱
 
 tooltip.add("create_dd:rubber_sapling", [`§6该品种树苗提供双倍树脂产量`]);
 
-tooltip.add("#quark:revertable_chests", [`§6注意右键合成该箱子会导致原箱子物品掉落`]);
+//tooltip.add("#quark:revertable_chests", [`§6注意右键合成该箱子会导致原箱子物品掉落`]);
 
 tooltip.add("create_dd:infaice", [`§3⑨`]);
 

--- a/kubejs/server_scripts/script.js
+++ b/kubejs/server_scripts/script.js
@@ -1974,7 +1974,9 @@ event.shaped(MC("chest"), [
 let woodCanMakeChest = [MC('oak'), MC('spruce'), MC('birch'), MC('jungle'), MC('acacia'), MC('dark_oak'), MC('crimson'), MC('warped'), MC('warped'), 'quark:azalea', 'quark:blossom']
 let woodChest = ['oak', 'spruce', 'birch', 'jungle', 'acacia', 'dark_oak', 'crimson', 'warped', 'warped', 'azalea', 'blossom']
 for (let i = 0; i <= (woodCanMakeChest.length - 1); i++) {
-	event.recipes.create.itemApplication("quark:" + woodChest[i] + "_chest", [MC("chest"), (woodCanMakeChest[i] + "_planks")])
+	//Fix: convert revertable_chests drop items
+	//event.recipes.create.itemApplication("quark:" + woodChest[i] + "_chest", [MC("chest"), (woodCanMakeChest[i] + "_planks")])
+	event.shapeless("quark:" + woodChest[i] + "_chest", [MC("chest"), (woodCanMakeChest[i] + "_planks")])
 }
 
 }


### PR DESCRIPTION
将原有的机械动力create.itemApplication配方替换成工作台无序合成，一个原版箱子加一个木板合成夸克mod的对应变种箱子
避免玩家手持木板右键箱子意外造成箱子物品全部掉落