### PR TITLE
优化镭射灯逻辑

### DIFF
--- a/kubejs/server_scripts/random_chemistry.js
+++ b/kubejs/server_scripts/random_chemistry.js
@@ -547,35 +547,24 @@ onEvent('block.left_click', event => {
         let te = laser.getEntity()
         if (!te)
             return
-        // 需要重置
-        //let nbt = Utils.newMap().toNBT()
-        /*let nbt = te.fullNBT
-        console.log("TE: " + te)
-        console.log("NBT: " + nbt)
-        let parts = nbt.getList("parts", 10)
-        let valid = false
-        let color = ""
-        if (parts) {
-            parts.forEach(part => {
-                if (!part.id.endsWith("_cage_light"))
-                    return
-                if (part.pow == part.id.contains("inverted"))
-                    return
-                if (part.side != face.getOpposite().ordinal())
-                    return
-                valid = true
-                color = part.id.replace("_inverted", "").replace("_cage_light", "").replace("projectred-illumination:", "")
-            })
-        }
 
-        if (!valid)
-            return
-        */
+        let invert
+
+        if(laser.entityData.parts[0].id.endsWith("inverted_cage_light")) invert=true
+        else if(laser.entityData.parts[0].id.endsWith("cage_light")) invert=false
+        else return
+
+        let pow=laser.entityData.parts[0].pow
+        if(pow&&invert||!pow&&!invert) return
+
+        let side=laser.entityData.parts[0].side
+        let faces={"up":0,"down":1,"south":2,"north":3,"east":4,"west":5}
+        if(faces[face]!=side) return
 
         let x = laser.x
         let y = laser.y
         let z = laser.z
-        let aabb = AABB.CUBE.move(x, y, z).inflate(4 * face.x, 4 * face.y, 4 * face.z)
+        let aabb = AABB.CUBE.move(x+2*face.x, y+2*face.y, z+2*face.z).inflate(2 * face.x, 2 * face.y, 2 * face.z)
         world.getEntitiesWithin(aabb).forEach(entity => {
             if (!entity.type.equals("minecraft:hopper_minecart")) {
                 if (!entity.type.equals("minecraft:item"))

--- a/kubejs/server_scripts/random_chemistry.js
+++ b/kubejs/server_scripts/random_chemistry.js
@@ -71,6 +71,7 @@ var cat = 0
 var digit = 0
 var digit2 = 0
 
+const FACES={"up":0,"down":1,"south":2,"north":3,"east":4,"west":5}
 function process(world, block, entity, face) {
 
     if (global.cachedSeed != world.getSeed()) {
@@ -558,8 +559,7 @@ onEvent('block.left_click', event => {
         if(pow&&invert||!pow&&!invert) return
 
         let side=laser.entityData.parts[0].side
-        let faces={"up":0,"down":1,"south":2,"north":3,"east":4,"west":5}
-        if(faces[face]!=side) return
+        if(FACES[face]!=side) return
 
         let x = laser.x
         let y = laser.y

--- a/kubejs/server_scripts/random_chemistry.js
+++ b/kubejs/server_scripts/random_chemistry.js
@@ -567,7 +567,7 @@ onEvent('block.left_click', event => {
         let aabb = AABB.CUBE.move(x+2*face.x, y+2*face.y, z+2*face.z).inflate(2 * face.x, 2 * face.y, 2 * face.z)
         world.getEntitiesWithin(aabb).forEach(entity => {
             if (!entity.type.equals("minecraft:hopper_minecart")) {
-                if (!entity.type.equals("minecraft:item"))
+                if (!["minecraft:item","minecraft:experience_orb"].includes(entity.type))
                     entity.attack("magic", 6)
                 return
             }


### PR DESCRIPTION
1.对multipart方块所含方块id进行判断，如果不属于cage_lamp则取消
2.未充能的笼灯和充能的反相笼灯（即未点亮笼灯）不会激活
3.判断方向，未附着于机器框架上的笼灯无效
4.优化伤害碰撞箱，确保对后方实体无效
5.伤害对experience_orb实体无效